### PR TITLE
Correct typo in input variable for timeout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
   password:
     description: "Steampunk Spotter password."
     required: false
-  timout:
+  timeout:
     description: "Steampunk Spotter API timeout (in seconds)."
     required: false
   config:


### PR DESCRIPTION
Correction of a small typo.